### PR TITLE
Recursively check whether GraphQLQueryTree.name is part of EntityMetadata.propertiesMap

### DIFF
--- a/src/classes/PerchQueryBuilder.ts
+++ b/src/classes/PerchQueryBuilder.ts
@@ -23,7 +23,7 @@ export class PerchQueryBuilder {
 
         const tree = GraphQLQueryTree.createTree(info);
 
-        const validFields = tree.fields.filter(item => repository.metadata.propertiesMap[item.name] || item.fields.length > 0);
+        const validFields = tree.fields.filter((field: GraphQLQueryTree<T>) => repository.metadata.propertiesMap[field.name] || field.isRelation());
 
         tree.fields = validFields;
 

--- a/src/classes/PerchQueryBuilder.ts
+++ b/src/classes/PerchQueryBuilder.ts
@@ -23,7 +23,7 @@ export class PerchQueryBuilder {
 
         const tree = GraphQLQueryTree.createTree(info);
 
-        const validFields = tree.fields.filter((field: GraphQLQueryTree<T>) => repository.metadata.propertiesMap[field.name] || field.isRelation());
+        const validFields = tree.fields.filter(field => repository.metadata.propertiesMap[field.name] || field.fields.length > 0);
 
         tree.fields = validFields;
 

--- a/src/functions/build-query-recursively.ts
+++ b/src/functions/build-query-recursively.ts
@@ -20,8 +20,7 @@ export function buildQueryRecursively<T>(
 
     // Firstly, we list all selected fields at this level of the query tree
     const selectedFields = tree.fields
-        .filter((field: GraphQLQueryTree<T>) => !field.isRelation())
-        .filter((field: GraphQLQueryTree<T>) => metadata.propertiesMap[field.name] || field.fields.length > 0)
+        .filter((field: GraphQLQueryTree<T>) => metadata.propertiesMap[field.name] && !field.isRelation())
         .map((field: GraphQLQueryTree<T>) => alias + "." + field.name);
 
     // Secondly, we list all fields used in arguments

--- a/src/functions/build-query-recursively.ts
+++ b/src/functions/build-query-recursively.ts
@@ -21,6 +21,7 @@ export function buildQueryRecursively<T>(
     // Firstly, we list all selected fields at this level of the query tree
     const selectedFields = tree.fields
         .filter((field: GraphQLQueryTree<T>) => !field.isRelation())
+        .filter((field: GraphQLQueryTree<T>) => metadata.propertiesMap[field.name] || field.fields.length > 0)
         .map((field: GraphQLQueryTree<T>) => alias + "." + field.name);
 
     // Secondly, we list all fields used in arguments


### PR DESCRIPTION
Fixes #11 

This makes it so that the recursive query builder also checks for all sub-fields whether the graphql field is actually part of the entity's propertiesMap.
Line was taken from:
https://github.com/wesleyyoung/perch-query-builder/blob/3b4bebfc04a8909420e0cad779e0294403bcca7e/src/classes/PerchQueryBuilder.ts#L26