### PR TITLE
Always select primary keys

### DIFF
--- a/src/classes/GraphQLQueryTree.ts
+++ b/src/classes/GraphQLQueryTree.ts
@@ -1,5 +1,6 @@
 import {GraphQLResolveInfo} from "graphql";
 import {buildQueryTree, GraphQLQueryTreeProperties} from "../";
+import {EntityMetadata} from "typeorm";
 
 
 /**
@@ -50,10 +51,10 @@ export class GraphQLQueryTree<T> {
     }
 
     /**
-     * @description Check if this field is a relation
+     * @description Check if this field is a relation in metadata
      */
-    public isRelation(): boolean {
-        return !!(this.fields && this.fields.length);
+    public isRelationIn(metadata: EntityMetadata): boolean {
+        return !!metadata.ownRelations.find((relation) => relation.propertyName === this.name);
     }
 
     /**

--- a/src/functions/build-query-recursively.ts
+++ b/src/functions/build-query-recursively.ts
@@ -1,6 +1,7 @@
 import {GraphQLQueryTree, PAGINATE} from "../";
 import {RelationMetadata} from "typeorm/metadata/RelationMetadata";
 import {EntityMetadata, SelectQueryBuilder} from "typeorm";
+import {ColumnMetadata} from "typeorm/metadata/ColumnMetadata";
 
 /**
  * @description Builds a TypeORM query with the queryBuilder recursively, joining every requested relation,
@@ -28,9 +29,14 @@ export function buildQueryRecursively<T>(
         .keys(tree.properties.args)
         .map((arg: string) => alias + "." + arg);
 
+    // Thirdly, we select all primary keys, to make sure that joined relations are not null
+    const primaryFields = metadata.primaryColumns
+        .map((ref: ColumnMetadata) => alias + "." + ref.propertyPath)
+
     // We select all of above
     qb.addSelect(argFields);
     qb.addSelect(selectedFields);
+    qb.addSelect(primaryFields)
 
     // We add order options
     Object.keys(options.order)

--- a/src/functions/build-query-recursively.ts
+++ b/src/functions/build-query-recursively.ts
@@ -21,7 +21,7 @@ export function buildQueryRecursively<T>(
 
     // Firstly, we list all selected fields at this level of the query tree
     const selectedFields = tree.fields
-        .filter((field: GraphQLQueryTree<T>) => !field.isRelation())
+        .filter((field: GraphQLQueryTree<T>) => !field.isRelationIn(metadata))
         .map((field: GraphQLQueryTree<T>) => alias + "." + field.name);
 
     // Secondly, we list all fields used in arguments
@@ -64,7 +64,7 @@ export function buildQueryRecursively<T>(
 
     // For each asked relation
     tree.fields
-        .filter((field: GraphQLQueryTree<T>) => field.isRelation())
+        .filter((field: GraphQLQueryTree<T>) => field.isRelationIn(metadata))
         .forEach((relationTree: GraphQLQueryTree<T>) => {
             const relation: RelationMetadata = metadata.findRelationWithPropertyPath(relationTree.name);
 


### PR DESCRIPTION
Fixes #9

This PR makes it so that the primary columns are always selected.
This will prevent joined relations from becoming null if no table column is selected