### PR TITLE
Allow custom root field for the automatic query builder

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './dynamic-query-options';
+export * from './query-builder-options';

--- a/src/interfaces/query-builder-options.ts
+++ b/src/interfaces/query-builder-options.ts
@@ -1,0 +1,17 @@
+import {SelectQueryBuilder} from "typeorm";
+
+/**
+ * @interface QueryBuilderOptions
+ * @description QueryBuilderOptions interface
+ */
+export interface QueryBuilderOptions<T> {
+    qb?: SelectQueryBuilder<T>;
+    /**
+     * Set a custom field that should be treated as the starting field for the automatic query builder.
+     * Can be a path.
+     * Examples: `field`, `field.subfield`
+     *
+     * @see https://github.com/wesleyyoung/perch-query-builder/issues/10
+     */
+    rootField?: string;
+}


### PR DESCRIPTION
Closes #10: a `rootField` argument.

It works perfectly fine, however, if you think the implementation is not a good fit for the library, I'd appreciate an alternative way to overcome the issue.

**Edit:** implementing other types of pagination in this library is a better way to go.
**Edit 2:** I don't think this is an ideal solution. 