### PR TITLE
Implement `@SelectAlways()` decorator

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,4 +5,5 @@ export * from './PAGINATE';
 export * from './Field';
 export * from './fragment-spread';
 export * from './inline-fragment';
+export * from './select-always';
 export * from './slice';

--- a/src/constants/select-always.ts
+++ b/src/constants/select-always.ts
@@ -1,0 +1,1 @@
+export const SELECT_ALWAYS = "perch:selectAlways";

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './select-always';

--- a/src/decorators/select-always.ts
+++ b/src/decorators/select-always.ts
@@ -1,0 +1,12 @@
+import {SELECT_ALWAYS} from "../constants";
+
+/**
+ * @description Force-selects columns, even if they are not in the GraphQL query. Handy if you use e.g. an `@AfterLoad()` that depends on a column.
+ */
+export function SelectAlways() {
+    return (target, property) => {
+        const metadata = Reflect.getMetadata(SELECT_ALWAYS, target) || [];
+        metadata.push(property);
+        Reflect.defineMetadata(SELECT_ALWAYS, metadata, target);
+    };
+}

--- a/src/functions/build-query-recursively.ts
+++ b/src/functions/build-query-recursively.ts
@@ -1,4 +1,4 @@
-import {GraphQLQueryTree, PAGINATE} from "../";
+import {GraphQLQueryTree, SELECT_ALWAYS} from "../";
 import {RelationMetadata} from "typeorm/metadata/RelationMetadata";
 import {EntityMetadata, SelectQueryBuilder} from "typeorm";
 
@@ -28,9 +28,20 @@ export function buildQueryRecursively<T>(
         .keys(tree.properties.args)
         .map((arg: string) => alias + "." + arg);
 
+    // Thirdly, we check the special selectAlways decorator data and force select those columns
+    let selectAlwaysFields = [];
+    if (typeof metadata.target == "function") {
+        const configuredFields = Reflect.getMetadata(SELECT_ALWAYS, metadata.target.prototype) || [];
+        selectAlwaysFields = configuredFields
+            // only select fields that are actually columns
+            .filter((propertyName) => Object.keys(metadata.propertiesMap).includes(propertyName))
+            .map((propertyName) => alias + "." + propertyName)
+    }
+
     // We select all of above
     qb.addSelect(argFields);
     qb.addSelect(selectedFields);
+    qb.addSelect(selectAlwaysFields);
 
     // We add order options
     Object.keys(options.order)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './arguments';
 export * from './types';
 export * from './constants';
 export * from './classes';
+export * from './decorators';
 export * from './functions';
 export * from './interfaces';
 export * from './object-types';


### PR DESCRIPTION
This is related to the (closed) issue https://github.com/wesleyyoung/perch-query-builder/issues/8. This PR implements my proposal of a `@SelectAlways()` decorator for columns. 

I found that if using, for example, an `@AfterLoad()` that depends on fields in the entity, it would be cleaner to use a decorator instead of manually adding `addSelect`s for the fields (like you suggested). I originally considered to encapsulate the `PerchQuerybuilder.generateQueryBuilder()` with a custom function in order to add the selects, however, I don't think it is ideal to hardcode a list of fields that should be selected, thus this PR.

This implementation only force-selects the column when its class relation is in the query:
```
parent (in query)
     child (not in query)
          property (not selected)

parent (in query)
     child (in query)
          property (selected)
```